### PR TITLE
Update pager colors, HN CSS selectors, intern regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Modules metadata
+go.mod
+go.sum

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func panicIf(err error) {
 }
 
 func displayPaginatedString(paginatedString string, pager string) {
-	cmd := exec.Command(pager)
+	cmd := exec.Command(pager, "-R")
 	cmd.Stdin = strings.NewReader(paginatedString)
 	cmd.Stdout = os.Stdout
 

--- a/main.go
+++ b/main.go
@@ -14,10 +14,9 @@ import (
 )
 
 var (
-	internRegex     = regexp.MustCompile(`(?i)[^\w](?:interns?|internship)[^\w]`)
-	ansiEscapeRegex = regexp.MustCompile(`[[:cntrl:]]`)
-	bayRegex        = regexp.MustCompile(`(?i)[^\w](?:san fran\w*|sf|bay area|mountain view|oakland|berkeley)[^\w]`)
-	dallasRegex     = regexp.MustCompile(`(?i)[^\w](?:dallas|dfw|fort worth|richardson)[^\w]`)
+	internRegex = regexp.MustCompile(`(?i)\b(interns?|internship)\b`)
+	bayRegex    = regexp.MustCompile(`(?i)[^\w](?:san fran\w*|sf|bay area|mountain view|oakland|berkeley)[^\w]`)
+	dallasRegex = regexp.MustCompile(`(?i)[^\w](?:dallas|dfw|fort worth|richardson)[^\w]`)
 
 	postTitleColor      = color.New(color.BgGreen).Add(color.Bold).SprintfFunc()
 	commentTitleColor   = color.New(color.BgBlue).SprintfFunc()
@@ -94,8 +93,8 @@ func getFormattedInternComments(url string) (formattedComments string, totalBay 
 
 		width, _ := comment.Find(".ind img").Attr("width")
 		if width == "0" {
-			innerP := comment.Find(".default > .comment > span > p")
-			rawText := comment.Find(".default > .comment > span").Eq(0).Text()
+			innerP := comment.Find(".default > .comment > .commtext > p")
+			rawText := comment.Find(".default > .comment > .commtext").Eq(0).Text()
 
 			firstLine := rawText[:strings.Index(rawText, innerP.Eq(0).Text())]
 


### PR DESCRIPTION
This PR aims to make a few changes in main.go (with some minor additions to .gitignore for metadata):
1. The `internRegex` didn't pick up on posts which had "intern" separated by non-digit, underscore, and digit characters (due to the `\w` in the pattern). So `\w` was changed to `\b` to pick up on characters such as backslashes.
2. The pagers on MacOS were updated to not pick up on ANSI color escape sequences (for security). However, the scraped text isn't colored — hardcoded text is. So passing in `-R` to the pager program shouldn't pose a large security risk, unless someone's using a custom pager. I can update this PR if you believe that case is likely.
3. The `goquery.Find(selector string) *goquery.Selection` on the comments in the HN page wasn't working. I suspect that this is due to HN updating their CSS class names in the time since 2016, when this tool was first made.

I'd like to also modify newspaper to work for jobs on HN as well or to perhaps scrape other sites as well. Would you be open to a PR with those modifications? If not, I can just work on it in my fork. Thanks!